### PR TITLE
Remove jQuery reference in example 7

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@
         new InstagramFeed({
             'username': 'instagram',
             'callback': function(data){
-                $('#jsonHere').html(JSON.stringify(data, null, 2));
+                document.getElementById("jsonHere").innerHTML = JSON.stringify(data, null, 2);
             }
         });
     })();


### PR DESCRIPTION
Do I need to bump the version for this small change? Just ask if that's the case.

Closes #39 

---

#### UNRELATED
Also I think you forgot to push the `1.3.7` tag for the commit 383eccc2a0dbe4316278a50a84a46994a153d8b5.  
Eventually the `1.0.0` tag is missing as well.